### PR TITLE
Remove selected attr from original HTML

### DIFF
--- a/js/selectToUISlider.jQuery.js
+++ b/js/selectToUISlider.jQuery.js
@@ -94,6 +94,7 @@ jQuery.fn.selectToUISlider = function(settings){
 
 				//control original select menu
 				var currSelect = jQuery('#' + thisHandle.attr('id').split('handle_')[1]);
+				currSelect.find('option').removeAttr('selected');
 				currSelect.find('option').eq(ui.value).attr('selected', 'selected');
 		},
 		values: (function(){


### PR DESCRIPTION
Removes the 'selected' attribute from the original select HTML. If this is not done, _every_ option that has been clicked on will have the 'selected' attribute set. Thus, the form will be submitted with the select value set to the latest selected option.
